### PR TITLE
Adding bower.json to allow registering with the Bower package repo

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "Ladda",
   "version": "0.5.1",
-  "main": ["./dist/ladda.min.js", "./dist/spin.mins.js"],
+  "main": ["./dist/ladda.min.js", "./dist/spin.min.js"],
   "devDependencies": {
     "grunt-contrib-jshint": "~0.2.0",
     "grunt-contrib-uglify": "~0.1.1",


### PR DESCRIPTION
I've added a `bower.json` file to the repo so this library can then be registered with [Bower](http://bower.io/)
