### PR TITLE
Changed zIndex to auto rather than initial

### DIFF
--- a/js/ladda.js
+++ b/js/ladda.js
@@ -282,7 +282,7 @@
 			radius: radius,
 			length: length,
 			width: width,
-			zIndex: 'initial',
+			zIndex: 'auto',
 			top: 'auto',
 			left: 'auto',
 			className: ''


### PR DESCRIPTION
Attempting to use initial as the zIndex on IE8 causes an error, which
stopped this working altogether with IE8.

Accoring to MDN the only valid values for this attribute are `auto` and
an integer: https://developer.mozilla.org/en-US/docs/Web/CSS/z-index
