### PR TITLE
Fixed jQuery form.submit event handling

### DIFF
--- a/js/ladda.js
+++ b/js/ladda.js
@@ -1,5 +1,5 @@
 /*!
- * Ladda 0.7.0
+ * Ladda 0.7.1
  * http://lab.hakim.se/ladda
  * MIT licensed
  *
@@ -65,7 +65,7 @@
 			 */
 			start: function() {
 
-				button.setAttribute( 'disabled', '' );
+				setTimeout( function() { button.setAttribute( 'disabled', '' ); }, 1 );
 				button.setAttribute( 'data-loading', '' );
 
 				clearTimeout( timer );


### PR DESCRIPTION
Ladda overrides jQuery form handlers by disabling button before form's `submit` event fires. Consider following code:

```
<form id="form" action="/wrong/url">
    <button type="submit" class="ladda-button" data-style="zoom-in">
        <span class="ladda-label">Submit</span>
        <span class="ladda-spinner"></span>
    </button>
</form>

<script>
    $(function() {
        Ladda.bind('.ladda-button');
    });

    $(function() {            
        $('#form').submit(function() {
            alert('submitted');
            return false;
        })
    });
</script>
```

And here is a live example: http://poma.su/ladda

After clicking button user will be redirected to `/wrong/url` instead of alert shown.
