### PR TITLE
Added remove method to button to stop memory leaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ l.toggle();
 
 // Check the current state
 l.isLoading();
+
+// Delete the button's ladda instance
+l.remove();
 ```
 
 All loading animations on the page can be stopped by using:

--- a/js/ladda.js
+++ b/js/ladda.js
@@ -179,6 +179,17 @@
 
 				return button.hasAttribute( 'data-loading' );
 
+			},
+
+			remove: function() {
+
+				for( var i = 0, len = ALL_INSTANCES.length; i < len; i++ ) {
+					if ( instance === ALL_INSTANCES[i] ) {
+						ALL_INSTANCES.splice(i, 1);
+						break;
+					}
+				}
+
 			}
 
 		};


### PR DESCRIPTION
This addition provides a way to delete a button's ladda instance. Calling this function properly will stop a memory leak caused by unused ladda instances piling up when buttons are constantly added and removed.
