### PR TITLE
Add browser hint to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
     "grunt-contrib-connect": "~0.2.0",
     "grunt": "~0.4.0"
   },
+  "browser": {
+    "spin.js": "./js/spin.js"
+  },
   "licenses": [
     {
       "type": "MIT",


### PR DESCRIPTION
This will allow font-end packagers to properly read ladda's spin.js dependency and bundle it. I think this is a logical addition if ladda is going to be distributed with a copy of spin.js included.