### PR TITLE
add ignore field to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,6 +5,13 @@
     "./dist/ladda.min.js",
     "./dist/ladda.min.css"
   ],
+  "ignore": [
+    "Gruntfile.js",
+    "package.json",
+    "js/spin.js",
+    "css",
+    "test"
+  ],
   "dependencies": {
     "spin.js": "~2.0.1"
   }


### PR DESCRIPTION
`package.json` should not be included in the bower distribution otherwise tools like `browserify` will attempt to use it and will fail hard when doing so.

@hakimel can you please review this and publish a new version to bower if you agree with the changeset?