### PR TITLE
Add 'main' field in package.json for easier CommonJS loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ladda
 
-Buttons with built-in loading indicators, effectively bridging the gap between action and feedback. 
+Buttons with built-in loading indicators, effectively bridging the gap between action and feedback.
 
 [Check out the demo page](http://lab.hakim.se/ladda/).
 
@@ -24,7 +24,7 @@ Buttons accepts three attributes:
 - **data-color**: green/red/blue/purple/mint
 - **data-size**: xs/s/l/xl, defaults to medium
 - **data-spinner-size**: 40, pixel dimensions of spinner, defaults to dynamic size based on the button height
-- **data-spinner-color**: A hex code or any [named CSS color](http://css-tricks.com/snippets/css/named-colors-and-hex-equivalents/). 
+- **data-spinner-color**: A hex code or any [named CSS color](http://css-tricks.com/snippets/css/named-colors-and-hex-equivalents/).
 
 #### JavaScript
 
@@ -123,7 +123,7 @@ define(['ladda'], function(Ladda) {
 Or in Common.js, you will:
 
 ```javascript
-var ladda = require('Ladda/dist/ladda.min');
+var ladda = require('ladda');
 ```
 
 ## Browser support

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.9.4",
   "description": "Buttons with built-in loading indicators",
   "homepage": "http://lab.hakim.se/ladda",
+  "main": "./dist/ladda.min",
   "scripts": {
     "test": "grunt jshint",
     "start": ""


### PR DESCRIPTION
Hi there,

for CommonJS / Browserify users, it is way easier to `require` modules by their name, rather than by a path. I just added the `main` field to the project's package.json to achieve this ([browserify documentation](https://github.com/substack/node-browserify#packagejson)), and also updated the example in the README.

BTW if you do not want to merge this PR, the current CommonJS example does not work because the path needs to be prefixed by `./` (`var ladda = require('./Ladda/dist/ladda.min');`).