### PR TITLE
Allow number spinner lines to be configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Buttons accepts three attributes:
 - **data-size**: xs/s/l/xl, defaults to medium
 - **data-spinner-size**: 40, pixel dimensions of spinner, defaults to dynamic size based on the button height
 - **data-spinner-color**: A hex code or any [named CSS color](http://css-tricks.com/snippets/css/named-colors-and-hex-equivalents/).
+- **data-spinner-lines**: 12, the number of lines the for the spinner, defaults to 12
 
 #### JavaScript
 

--- a/js/ladda.js
+++ b/js/ladda.js
@@ -362,7 +362,8 @@
 	function createSpinner( button ) {
 
 		var height = button.offsetHeight,
-			spinnerColor;
+			spinnerColor,
+			spinnerLines;
 
 		if( height === 0 ) {
 			// We may have an element that is not visible so
@@ -385,14 +386,18 @@
 			spinnerColor = button.getAttribute( 'data-spinner-color' );
 		}
 
-		var lines = 12,
-			radius = height * 0.2,
+		// Allow buttons to specify the number of lines of the spinner
+		if( button.hasAttribute( 'data-spinner-lines' ) ) {
+			spinnerLines = parseInt( button.getAttribute( 'data-spinner-lines' ), 10 );
+		}
+
+		var radius = height * 0.2,
 			length = radius * 0.6,
 			width = radius < 7 ? 2 : 3;
 
 		return new Spinner( {
 			color: spinnerColor || '#fff',
-			lines: lines,
+			lines: spinnerLines || 12,
 			radius: radius,
 			length: length,
 			width: width,


### PR DESCRIPTION
* Use `data-spinner-lines` attribute if supplied to set the number
  of lines the spinner will use.
* Default number of lines to 12.

@hakimel 
Needed this config for a work project, figured it might be useful for others.