### PR TITLE
Play nicely with browserify / browserify-shim.

### DIFF
--- a/js/spin.js
+++ b/js/spin.js
@@ -4,14 +4,19 @@
  */
 (function(root, factory) {
 
-  /* CommonJS */
-  if (typeof exports == 'object')  module.exports = factory()
+  // CommonJS
+  if (typeof exports == 'object') {
+    module.exports = factory();
+  }
+  // AMD module
+  else if (typeof define == 'function' && define.amd) {
+    define(factory);
+  }
+  // Browser global
+  else {
+    root.Spinner = factory();
+  }
 
-  /* AMD module */
-  else if (typeof define == 'function' && define.amd) define(factory)
-
-  /* Browser global */
-  else root.Spinner = factory()
 }
 (this, function() {
   "use strict";


### PR DESCRIPTION
 Because of the formatting in `js/spin.js` to date, I have been getting
a parse error [here](https://github.com/hakimel/Ladda/blob/master/js/spin.js#L14)

```
Line 14: Unexpected token else while parsing ./..../spin.js
```

Better formatting was applied to `js/ladda.js` nearly 2 years ago in 5f7915680a96cd3e749a1458bd49ddb044bd5510

This change to `js/spin.js` fixes this and aligns well with the change made to `js/ladda.js` years ago.