### PR TITLE
URL validation to require http/https and one character

### DIFF
--- a/js/ladda.js
+++ b/js/ladda.js
@@ -335,6 +335,10 @@
 										valid = /^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$/.test( requireds[i].value );
 									}
 
+									// URL field validation, requires http:// or https:// and 1 character
+									if( requireds[i].type === 'url' ) {
+										valid = /https?:\/\/.+/.test( requireds[i].value );
+									}
 								}
 							}
 						}


### PR DESCRIPTION
On fallback to browsers that don't support html5 validation a field of `type="url"` should be validated to require minimum http or https and one character (this seems to be what chrome uses at least for their hmtl5 validation)
