### PR TITLE
Fix for jQuery version of isLoading()

### DIFF
--- a/js/ladda.jquery.js
+++ b/js/ladda.jquery.js
@@ -27,6 +27,10 @@
 				args.unshift( $( this ).selector );
 				Ladda.bind.apply( Ladda, args );
 			}
+			else if ( arg === 'isLoading' ) {
+				var ladda = $(this).data( 'ladda' );
+				return ladda.isLoading();
+			}
 			else {
 				$( this ).each( function() {
 					var $this = $( this ), ladda;


### PR DESCRIPTION
Currently `$(".ladda-button").ladda("isLoading")` doesn't work (the jQuery selector is returned instead of the boolean). This change makes it work (for the first matched button in the selector, but running it on multiple buttons doesn't really make sense).
