### PR TITLE
Include Sass files in npm package and allow $spinnerSize Sass variable to be reassigned

### DIFF
--- a/css/ladda.scss
+++ b/css/ladda.scss
@@ -99,7 +99,10 @@ $spinnerSize: 32px;
  * EASING
  */
 
-.ladda-button,
+.ladda-button {
+	@include transition( 0.3s cubic-bezier(0.175, 0.885, 0.320, 1.275) padding );
+}
+
 .ladda-button .ladda-spinner,
 .ladda-button .ladda-label {
 	@include transition( 0.3s cubic-bezier(0.175, 0.885, 0.320, 1.275) all );

--- a/css/ladda.scss
+++ b/css/ladda.scss
@@ -11,7 +11,7 @@
  * CONFIG
  */
 
-$spinnerSize: 32px;
+$spinnerSize: 32px !default;
 
 
 /*************************************

--- a/css/ladda.scss
+++ b/css/ladda.scss
@@ -99,10 +99,7 @@ $spinnerSize: 32px !default;
  * EASING
  */
 
-.ladda-button {
-	@include transition( 0.3s cubic-bezier(0.175, 0.885, 0.320, 1.275) padding );
-}
-
+.ladda-button,
 .ladda-button .ladda-spinner,
 .ladda-button .ladda-label {
 	@include transition( 0.3s cubic-bezier(0.175, 0.885, 0.320, 1.275) all );

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Buttons with built-in loading indicators",
   "homepage": "http://lab.hakim.se/ladda",
   "files": [
+    "css/*.scss",
     "dist/*.css",
     "js/ladda.d.ts",
     "js/ladda.js"


### PR DESCRIPTION
There are 2 commits:

- solve [this](https://github.com/hakimel/Ladda/issues/70) in a way, by isolating transition to padding, and not transitioning background-color and color.

- adding `!default` to sass variable which allows reassigning.

Hope it helps.